### PR TITLE
TLS should not check the host name by default.

### DIFF
--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -582,7 +582,7 @@ module Net
       logging "TLS connection started"
       s.sync_close = true
       ssl_socket_connect(s, @open_timeout)
-      if @ssl_context.verify_mode != OpenSSL::SSL::VERIFY_NONE
+      if @ssl_context.verify_mode && @ssl_context.verify_mode != OpenSSL::SSL::VERIFY_NONE
         s.post_connection_check(@address)
       end
       verified = true

--- a/test/net/smtp/test_ssl_socket.rb
+++ b/test/net/smtp/test_ssl_socket.rb
@@ -53,8 +53,10 @@ module Net
         end
       }
 
+      ssl_context = OpenSSL::SSL::SSLContext.new
+      ssl_context.verify_mode = OpenSSL::SSL::VERIFY_PEER
       connection = MySMTP.new('localhost', 25)
-      connection.enable_starttls_auto
+      connection.enable_starttls_auto(ssl_context)
       connection.fake_tcp = tcp_socket
       connection.fake_ssl = ssl_socket
 


### PR DESCRIPTION
In tlsconnect(), the host name is checked when @ssl_context.verify_mode is not OpenSSL::SSL::VERIFY_NONE, but the verify_mode of @ssl_context generated by default is nil.