### PR TITLE
INCOMPATIBLE CHANGE: Verify the server's certificate by default.

### DIFF
--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -129,7 +129,7 @@ module Net
         smtp = Net::SMTP.new("localhost", servers[0].local_address.ip_port)
         smtp.enable_tls
         smtp.open_timeout = 1
-        smtp.start do
+        smtp.start(tls_verify: false) do
         end
       ensure
         sock.close if sock

--- a/test/net/smtp/test_sslcontext.rb
+++ b/test/net/smtp/test_sslcontext.rb
@@ -25,7 +25,9 @@ module Net
 
       def ssl_socket(socket, context)
         @__ssl_context = context
-        super
+        s = super
+        s.define_singleton_method(:post_connection_check){|_|}
+        s
       end
     end
 
@@ -60,7 +62,7 @@ module Net
     def test_default
       smtp = MySMTP.new(start_smtpd(true))
       smtp.start
-      assert_not_nil(smtp.__ssl_context)
+      assert_equal(OpenSSL::SSL::VERIFY_PEER, smtp.__ssl_context.verify_mode)
     end
 
     def test_enable_tls
@@ -95,6 +97,18 @@ module Net
       smtp.disable_tls
       smtp.start
       assert_equal(context, smtp.__ssl_context)
+    end
+
+    def test_start_with_tls_verify_true
+      smtp = MySMTP.new(start_smtpd(true))
+      smtp.start(tls_verify: true)
+      assert_equal(OpenSSL::SSL::VERIFY_PEER, smtp.__ssl_context.verify_mode)
+    end
+
+    def test_start_with_tls_verify_false
+      smtp = MySMTP.new(start_smtpd(true))
+      smtp.start(tls_verify: false)
+      assert_equal(OpenSSL::SSL::VERIFY_NONE, smtp.__ssl_context.verify_mode)
     end
   end
 end


### PR DESCRIPTION
To prevent verification, specify start(tls_verify: false).