### PR TITLE
Removed needless files from Gem::Specification#files

### DIFF
--- a/net-smtp.gemspec
+++ b/net-smtp.gemspec
@@ -22,9 +22,11 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
 
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z 2>/dev/null`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  end
+  spec.files         = %w[
+    LICENSE.txt
+    lib/net/smtp.rb
+    net-smtp.gemspec
+  ]
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
The current implementation gives the following files by `gem install net-smtp`

```
.github/workflows/test.yml
.gitignore
Gemfile
LICENSE.txt
NEWS.md
README.md
Rakefile
bin/console
bin/setup
lib/net/smtp.rb
net-smtp.gemspec
test/net/fixtures/cacert.pem
test/net/fixtures/dhparams.pem
test/net/fixtures/server.crt
test/net/fixtures/server.key
test/net/smtp/test_response.rb
test/net/smtp/test_smtp.rb
test/net/smtp/test_ssl_socket.rb
test/net/smtp/test_sslcontext.rb
test/net/smtp/test_starttls.rb
```

I removed the needless files from them.