### PR TITLE
Replace Timeout.timeout with socket timeout

### DIFF
--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -575,7 +575,12 @@ module Net
     private
 
     def tcp_socket(address, port)
-      TCPSocket.open address, port
+      begin
+        Socket.tcp address, port, nil, nil, connect_timeout: @open_timeout
+      rescue Errno::ETIMEDOUT #raise Net:OpenTimeout instead for compatibility with previous versions
+        raise Net::OpenTimeout, "Timeout to open TCP connection to "\
+          "#{address}:#{port} (exceeds #{@open_timeout} seconds)"
+      end
     end
 
     def do_start(helo_domain, user, secret, authtype)
@@ -584,9 +589,7 @@ module Net
         check_auth_method(authtype || DEFAULT_AUTH_TYPE)
         check_auth_args user, secret
       end
-      s = Timeout.timeout(@open_timeout, Net::OpenTimeout) do
-        tcp_socket(@address, @port)
-      end
+      s = tcp_socket(@address, @port)
       logging "Connection opened: #{@address}:#{@port}"
       @socket = new_internet_message_io(tls? ? tlsconnect(s, @ssl_context_tls) : s)
       check_response critical { recv_response() }


### PR DESCRIPTION
Timeout.timeout is inefficient since it spins up a new thread for each invocation, use Socket.tcp's connect_timeout option instead