### PR TITLE
Add response to SMTPError exceptions

### DIFF
--- a/test/net/smtp/test_starttls.rb
+++ b/test/net/smtp/test_starttls.rb
@@ -76,6 +76,7 @@ module Net
       smtp.enable_starttls
       err = assert_raise(Net::SMTPUnsupportedCommand) { smtp.start }
       assert_equal("STARTTLS is not supported on this server", err.message)
+      assert_nil(err.response)
     end
 
     def test_enable_starttls_auto_with_starttls_capable


### PR DESCRIPTION
Right now there is no way to get response status, which is useful for
metrics and similar stuff. Add response to the exception, so it could
be used for that.

And add a bunch of tests to actually test it.