### PR TITLE
README: fix Markdown format in link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This library provides functionality to send internet mail via SMTP, the Simple Mail Transfer Protocol.
 
-For details of SMTP itself, see [RFC2821] (http://www.ietf.org/rfc/rfc2821.txt).
+For details of SMTP itself, see [RFC2821](http://www.ietf.org/rfc/rfc2821.txt).
 
 ## Installation
 


### PR DESCRIPTION
This PR repairs a broken link in the README.