### PR TITLE
gemspec: Remove unused "executables" directive

### DIFF
--- a/net-smtp.gemspec
+++ b/net-smtp.gemspec
@@ -27,8 +27,6 @@ Gem::Specification.new do |spec|
     lib/net/smtp.rb
     net-smtp.gemspec
   ]
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "net-protocol"


### PR DESCRIPTION
This gem exposes 0 executables.