### PR TITLE
add Net::SMTP::Address

### DIFF
--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -703,9 +703,9 @@ module Net
     # binary message with this method. +msgstr+ should include both
     # the message headers and body.
     #
-    # +from_addr+ is a String representing the source mail address.
+    # +from_addr+ is a String or Net::SMTP::Address representing the source mail address.
     #
-    # +to_addr+ is a String or Strings or Array of Strings, representing
+    # +to_addr+ is a String or Net::SMTP::Address or Array of them, representing
     # the destination mail address or addresses.
     #
     # === Example
@@ -714,6 +714,12 @@ module Net
     #       smtp.send_message msgstr,
     #                         'from@example.com',
     #                         ['dest@example.com', 'dest2@example.com']
+    #     end
+    #
+    #     Net::SMTP.start('smtp.example.com') do |smtp|
+    #       smtp.send_message msgstr,
+    #                         Net::SMTP::Address.new('from@example.com', size: 12345),
+    #                         Net::SMTP::Address.new('dest@example.com', notify: :success)
     #     end
     #
     # === Errors
@@ -752,9 +758,9 @@ module Net
     #
     # === Parameters
     #
-    # +from_addr+ is a String representing the source mail address.
+    # +from_addr+ is a String or Net::SMTP::Address representing the source mail address.
     #
-    # +to_addr+ is a String or Strings or Array of Strings, representing
+    # +to_addr+ is a String or Net::SMTP::Address or Array of them, representing
     # the destination mail address or addresses.
     #
     # === Example
@@ -904,8 +910,10 @@ module Net
       getok("EHLO #{domain}")
     end
 
+    # +from_addr+ is +String+ or +Net::SMTP::Address+
     def mailfrom(from_addr)
-      getok("MAIL FROM:<#{from_addr}>")
+      addr = Address.new(from_addr)
+      getok((["MAIL FROM:<#{addr.address}>"] + addr.parameters).join(' '))
     end
 
     def rcptto_list(to_addrs)
@@ -916,7 +924,7 @@ module Net
         begin
           rcptto addr
         rescue SMTPAuthenticationError
-          unknown_users << addr.dump
+          unknown_users << addr.to_s.dump
         else
           ok_users << addr
         end
@@ -929,8 +937,10 @@ module Net
       ret
     end
 
+    # +to_addr+ is +String+ or +Net::SMTP::Address+
     def rcptto(to_addr)
-      getok("RCPT TO:<#{to_addr}>")
+      addr = Address.new(to_addr)
+      getok((["RCPT TO:<#{addr.address}>"] + addr.parameters).join(' '))
     end
 
     # This method sends a message.
@@ -1137,6 +1147,33 @@ module Net
 
     def logging(msg)
       @debug_output << msg + "\n" if @debug_output
+    end
+
+    # Address with parametres for MAIL or RCPT command
+    class Address
+      # mail address [String]
+      attr_reader :address
+      # paramters [Array<String>]
+      attr_reader :parameters
+
+      # :call-seq:
+      #  initialize(address, parameter, ...)
+      #
+      # address +String+ or +Net::SMTP::Address+
+      # parameter +String+ or +Hash+
+      def initialize(address, *args, **kw_args)
+        if address.kind_of? Address
+          @address = address.address
+          @parameters = address.parameters
+        else
+          @address = address
+          @parameters = (args + [kw_args]).map{|param| Array(param)}.flatten(1).map{|param| Array(param).compact.join('=')}
+        end
+      end
+
+      def to_s
+        @address
+      end
     end
 
   end   # class SMTP

--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -274,11 +274,14 @@ module Net
       capable?('STARTTLS')
     end
 
+    # true if the EHLO response contains +key+.
     def capable?(key)
       return nil unless @capabilities
       @capabilities[key] ? true : false
     end
-    private :capable?
+
+    # The server capabilities by EHLO response
+    attr_reader :capabilities
 
     # true if server advertises AUTH PLAIN.
     # You cannot get valid value before opening SMTP session.

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -70,6 +70,15 @@ module Net
       assert_equal 'omg', smtp.esmtp?
     end
 
+    def test_server_capabilities
+      port = fake_server_start(starttls: true)
+      smtp = Net::SMTP.start('localhost', port, starttls: false)
+      assert_equal({"STARTTLS"=>[], "AUTH"=>["PLAIN"]}, smtp.capabilities)
+      assert_equal(true, smtp.capable?('STARTTLS'))
+      assert_equal(false, smtp.capable?('SMTPUTF8'))
+      smtp.finish
+    end
+
     def test_rset
       smtp = Net::SMTP.new 'localhost', 25
       smtp.instance_variable_set :@socket, FakeSocket.new

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -85,12 +85,36 @@ module Net
       assert_equal "MAIL FROM:<foo@example.com>\r\n", sock.write_io.string
     end
 
+    def test_mailfrom_with_address
+      sock = FakeSocket.new
+      smtp = Net::SMTP.new 'localhost', 25
+      smtp.instance_variable_set :@socket, sock
+      addr = Net::SMTP::Address.new("foo@example.com", size: 12345)
+      assert smtp.mailfrom(addr).success?
+      assert_equal "MAIL FROM:<foo@example.com> size=12345\r\n", sock.write_io.string
+    end
+
     def test_rcptto
       sock = FakeSocket.new
       smtp = Net::SMTP.new 'localhost', 25
       smtp.instance_variable_set :@socket, sock
       assert smtp.rcptto("foo@example.com").success?
       assert_equal "RCPT TO:<foo@example.com>\r\n", sock.write_io.string
+    end
+
+    def test_rcptto_with_address
+      sock = FakeSocket.new
+      smtp = Net::SMTP.new 'localhost', 25
+      smtp.instance_variable_set :@socket, sock
+      addr = Net::SMTP::Address.new("foo@example.com", nofty: :failure)
+      assert smtp.rcptto(addr).success?
+      assert_equal "RCPT TO:<foo@example.com> nofty=failure\r\n", sock.write_io.string
+    end
+
+    def test_address
+      a = Net::SMTP::Address.new('foo@example.com', 'p0=123', {p1: 456}, p2: nil, p3: '789')
+      assert_equal 'foo@example.com', a.address
+      assert_equal ['p0=123', 'p1=456', 'p2', 'p3=789'], a.parameters
     end
 
     def test_auth_plain


### PR DESCRIPTION
To add parameters for MAIL FROM or RCPT TO:
```ruby
smtp.send_message("msg", Net::STMP::Address.new("sender@example.com", size: 12345),
  Net::SMTP::Address("rcpt@example.com", notify: :success))
```
on SMTP
```
MAIL FROM:<sender@example.com> size=12345
...
RCPT TO:<rctp@example.com> notify=ssuccess
```

https://bugs.ruby-lang.org/issues/17047