### PR TITLE
Remove needless dependencies

### DIFF
--- a/net-smtp.gemspec
+++ b/net-smtp.gemspec
@@ -30,6 +30,4 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "net-protocol"
-  spec.add_dependency "digest"
-  spec.add_dependency "timeout"
 end


### PR DESCRIPTION
These are default gems, so there is no need to explicitly depend on them,
and depending on them is actually harmful: https://bugs.ruby-lang.org/issues/18567.