### PR TITLE
Make exception API compatible with what Ruby expects

### DIFF
--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -35,8 +35,13 @@ module Net
     attr_reader :response
 
     def initialize(response, message: nil)
-      @response = response
-      @message = message
+      if response.is_a?(::Net::SMTP::Response)
+        @response = response
+        @message = message
+      else
+        @response = nil
+        @message = message || response 
+      end
     end
 
     def message
@@ -643,7 +648,7 @@ module Net
       do_helo helo_domain
       if ! tls? and (starttls_always? or (capable_starttls? and starttls_auto?))
         unless capable_starttls?
-          raise SMTPUnsupportedCommand.new(nil, message: "STARTTLS is not supported on this server")
+          raise SMTPUnsupportedCommand, "STARTTLS is not supported on this server"
         end
         starttls
         @socket = new_internet_message_io(tlsconnect(s, @ssl_context_starttls))


### PR DESCRIPTION
Ruby expects that the first argument to Exception#initialize is a
string (or nil), since that is what Kernel#raise uses.  Breaking that
assumption is a very bad idea.

This problem was introduced in 16be09a60c77bcf7ce10fa91cc3689c0d11b0f4b.
A backwards compatible approach would have added a response keyword
argument.  Unfortunately, that ship has sailed, unless we want to break
backwards compatibility again.

Try to restore backwards compatibility and align with standard Ruby
exception behavior by checking whether the first message to #initialize
is an STMP::Response.  If so, use it as the response.  If not, treat it
as the exception message.

This prevents issues in code that does something like:

```ruby
  raise exception_class, exception_message
```

Before this change, you'll get a NoMethodError later inside of
SMTPError#message, with no indication of the actual problem.