### PR TITLE
Use OpenSSL::Digest instead of digest gem

### DIFF
--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -22,6 +22,7 @@ require 'timeout'
 begin
   require 'openssl'
 rescue LoadError
+  raise 'openssl library not installed'
 end
 
 module Net
@@ -340,7 +341,6 @@ module Net
     # this object.  Must be called before the connection is established
     # to have any effect.  +context+ is a OpenSSL::SSL::SSLContext object.
     def enable_tls(context = nil)
-      raise 'openssl library not installed' unless defined?(OpenSSL::VERSION)
       raise ArgumentError, "SMTPS and STARTTLS is exclusive" if @starttls == :always
       @tls = true
       @ssl_context_tls = context
@@ -377,7 +377,6 @@ module Net
     # Enables SMTP/TLS (STARTTLS) for this object.
     # +context+ is a OpenSSL::SSL::SSLContext object.
     def enable_starttls(context = nil)
-      raise 'openssl library not installed' unless defined?(OpenSSL::VERSION)
       raise ArgumentError, "SMTPS and STARTTLS is exclusive" if @tls
       @starttls = :always
       @ssl_context_starttls = context
@@ -386,7 +385,6 @@ module Net
     # Enables SMTP/TLS (STARTTLS) for this object if server accepts.
     # +context+ is a OpenSSL::SSL::SSLContext object.
     def enable_starttls_auto(context = nil)
-      raise 'openssl library not installed' unless defined?(OpenSSL::VERSION)
       raise ArgumentError, "SMTPS and STARTTLS is exclusive" if @tls
       @starttls = :auto
       @ssl_context_starttls = context

--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -885,14 +885,14 @@ module Net
 
     # CRAM-MD5: [RFC2195]
     def cram_md5_response(secret, challenge)
-      tmp = OpenSSL::Digest::MD5.digest(cram_secret(secret, IMASK) + challenge)
-      OpenSSL::Digest::MD5.hexdigest(cram_secret(secret, OMASK) + tmp)
+      tmp = OpenSSL::Digest.digest("MD5", cram_secret(secret, IMASK) + challenge)
+      OpenSSL::Digest.hexdigest("MD5", cram_secret(secret, OMASK) + tmp)
     end
 
     CRAM_BUFSIZE = 64
 
     def cram_secret(secret, mask)
-      secret = OpenSSL::Digest::MD5.digest(secret) if secret.size > CRAM_BUFSIZE
+      secret = OpenSSL::Digest.digest("MD5", secret) if secret.size > CRAM_BUFSIZE
       buf = secret.ljust(CRAM_BUFSIZE, "\0")
       0.upto(buf.size - 1) do |i|
         buf[i] = (buf[i].ord ^ mask).chr

--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -18,7 +18,6 @@
 #
 
 require 'net/protocol'
-require 'digest/md5'
 require 'timeout'
 begin
   require 'openssl'
@@ -888,14 +887,14 @@ module Net
 
     # CRAM-MD5: [RFC2195]
     def cram_md5_response(secret, challenge)
-      tmp = Digest::MD5.digest(cram_secret(secret, IMASK) + challenge)
-      Digest::MD5.hexdigest(cram_secret(secret, OMASK) + tmp)
+      tmp = OpenSSL::Digest::MD5.digest(cram_secret(secret, IMASK) + challenge)
+      OpenSSL::Digest::MD5.hexdigest(cram_secret(secret, OMASK) + tmp)
     end
 
     CRAM_BUFSIZE = 64
 
     def cram_secret(secret, mask)
-      secret = Digest::MD5.digest(secret) if secret.size > CRAM_BUFSIZE
+      secret = OpenSSL::Digest::MD5.digest(secret) if secret.size > CRAM_BUFSIZE
       buf = secret.ljust(CRAM_BUFSIZE, "\0")
       0.upto(buf.size - 1) do |i|
         buf[i] = (buf[i].ord ^ mask).chr


### PR DESCRIPTION
`digest` has been removed at https://github.com/ruby/net-smtp/pull/38.

On another note, `openssl` provide digest methods same as `digest`. We should use `OpenSSL::Digest` for reducing dependencies.