### PR TITLE
Add XOAUTH2 authenticator

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,9 @@
 # NEWS
+## Unreleased
+
+### Improvements
+
+* Add XOAUTH2 authenticator <https://github.com/ruby/net-smtp/pull/47>
 
 ## Version 0.3.3 (2022-10-29)
 

--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -936,7 +936,7 @@ module Net
     end
 
     def build_oauth2_string(user, oauth2_token)
-      "user=%s\1auth=Bearer %s\1\1".encode("us-ascii") % [user, oauth2_token]
+      format("user=%s\1auth=Bearer %s\1\1", user, oauth2_token)
     end
 
     def get_final_status

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -151,6 +151,23 @@ module Net
       assert_equal "535", err.response.status
     end
 
+    def test_auth_xoauth2
+      sock = FakeSocket.new("235 2.7.0 Authentication successful\r\n")
+      smtp = Net::SMTP.new 'localhost', 25
+      smtp.instance_variable_set :@socket, sock
+      assert smtp.auth_xoauth2("foo", "bar").success?
+      assert_equal "AUTH XOAUTH2 dXNlcj1mb28BYXV0aD1CZWFyZXIgYmFyAQE=\r\n", sock.write_io.string
+    end
+
+    def test_unsucessful_auth_xoauth2
+      sock = FakeSocket.new("535 5.7.8 BadCredentials\r\n")
+      smtp = Net::SMTP.new 'localhost', 25
+      smtp.instance_variable_set :@socket, sock
+      err = assert_raise(Net::SMTPAuthenticationError) { smtp.auth_xoauth2("foo", "bar") }
+      assert_equal "535 5.7.8 BadCredentials\n", err.message
+      assert_equal "535", err.response.status
+    end
+
     def test_auth_login
       sock = FakeSocket.new("334 VXNlcm5hbWU6\r\n334 UGFzc3dvcmQ6\r\n235 2.7.0 Authentication successful\r\n")
       smtp = Net::SMTP.new 'localhost', 25


### PR DESCRIPTION
fixes https://github.com/ruby/net-smtp/issues/46

it's based on https://github.com/nfo/gmail_xoauth and similar to https://github.com/ruby/net-imap/pull/63 which was merged. It would be nice to support the same feature level for SMTP.

cc @shugo 