### PR TITLE
Handle, in the `rcptto_list` method, a mixture of recipient statuses.

### DIFF
--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -771,7 +771,7 @@ module Net
     def send_message(msgstr, from_addr, *to_addrs)
       raise IOError, 'closed session' unless @socket
       mailfrom from_addr
-      rcptto_list(to_addrs) {data msgstr}
+      rcptto_list(to_addrs.flatten) {data msgstr}
     end
 
     alias send_mail send_message
@@ -825,7 +825,7 @@ module Net
     def open_message_stream(from_addr, *to_addrs, &block)   # :yield: stream
       raise IOError, 'closed session' unless @socket
       mailfrom from_addr
-      rcptto_list(to_addrs) {data(&block)}
+      rcptto_list(to_addrs.flatten) {data(&block)}
     end
 
     alias ready open_message_stream   # obsolete

--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -66,8 +66,13 @@ module Net
     include SMTPError
   end
 
-  # Represents a fatal SMTP error (error code 5xx, except for 500 and 53x)
+  # Represents a fatal SMTP error (error code 5xx, except for 500, 53x, and 55x)
   class SMTPFatalError < ProtoFatalError
+    include SMTPError
+  end
+
+  # Represents a fatal SMTP error pertaining to the mailbox (error code 55x)
+  class SMTPMailboxPermanentlyUnavailable < ProtoFatalError
     include SMTPError
   end
 
@@ -510,6 +515,7 @@ module Net
     # * Net::SMTPServerBusy
     # * Net::SMTPSyntaxError
     # * Net::SMTPFatalError
+    # * Net::SMTPMailboxPermanentlyUnavailable
     # * Net::SMTPUnknownError
     # * Net::OpenTimeout
     # * Net::ReadTimeout
@@ -583,6 +589,7 @@ module Net
     # * Net::SMTPServerBusy
     # * Net::SMTPSyntaxError
     # * Net::SMTPFatalError
+    # * Net::SMTPMailboxPermanentlyUnavailable
     # * Net::SMTPUnknownError
     # * Net::OpenTimeout
     # * Net::ReadTimeout
@@ -752,9 +759,11 @@ module Net
     #
     # This method may raise:
     #
+    # * Net::SMTPAuthenticationError
     # * Net::SMTPServerBusy
     # * Net::SMTPSyntaxError
     # * Net::SMTPFatalError
+    # * Net::SMTPMailboxPermanentlyUnavailable
     # * Net::SMTPUnknownError
     # * Net::ReadTimeout
     # * IOError
@@ -808,6 +817,7 @@ module Net
     # * Net::SMTPServerBusy
     # * Net::SMTPSyntaxError
     # * Net::SMTPFatalError
+    # * Net::SMTPMailboxPermanentlyUnavailable
     # * Net::SMTPUnknownError
     # * Net::ReadTimeout
     # * IOError
@@ -1165,6 +1175,7 @@ module Net
         when /\A4/  then SMTPServerBusy
         when /\A50/ then SMTPSyntaxError
         when /\A53/ then SMTPAuthenticationError
+        when /\A55/ then SMTPMailboxPermanentlyUnavailable
         when /\A5/  then SMTPFatalError
         else             SMTPUnknownError
         end

--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -42,7 +42,7 @@ module Net
         @message = message
       else
         @response = nil
-        @message = message || response 
+        @message = message || response
       end
     end
 
@@ -51,7 +51,7 @@ module Net
     end
   end
 
-  # Represents an SMTP authentication error.
+  # Represents an SMTP authentication error (error code 53x).
   class SMTPAuthenticationError < ProtoAuthError
     include SMTPError
   end
@@ -66,7 +66,7 @@ module Net
     include SMTPError
   end
 
-  # Represents a fatal SMTP error (error code 5xx, except for 500)
+  # Represents a fatal SMTP error (error code 5xx, except for 500 and 53x)
   class SMTPFatalError < ProtoFatalError
     include SMTPError
   end

--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -72,7 +72,7 @@ module Net
   end
 
   # Represents a fatal SMTP error pertaining to the mailbox (error code 55x)
-  class SMTPMailboxPermanentlyUnavailable < ProtoFatalError
+  class SMTPMailboxPermanentlyUnavailable < SMTPFatalError
     include SMTPError
   end
 

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -617,7 +617,9 @@ module Net
       smtp = Net::SMTP.new('localhost', port)
       smtp.start do |conn|
         conn.mailfrom "me@example.org"
-        conn.rcptto_list [] do end
+        assert_raise ArgumentError do
+          conn.rcptto_list [] do end
+        end
       end
       assert_equal [], @recipients
     end
@@ -627,7 +629,9 @@ module Net
       smtp = Net::SMTP.new('localhost', port)
       smtp.start do |conn|
         conn.mailfrom "me@example.org"
-        conn.rcptto_list ["nonexistent1@example.net", "nonexistent2@example.net"] do end
+        assert_raise ArgumentError do
+          conn.rcptto_list ["nonexistent1@example.net", "nonexistent2@example.net"] do end
+        end
       end
       assert_equal [], @recipients
     end

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -566,6 +566,7 @@ module Net
       smtp.start do |conn|
         conn.send_message "test", "me@example.org", ["you@example.net", "friend@example.net"]
       end
+      assert_equal %w[you@example.net friend@example.net], @recipients
     end
 
     private

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -605,9 +605,11 @@ module Net
       smtp = Net::SMTP.new('localhost', port)
       smtp.start do |conn|
         conn.mailfrom "me@example.org"
-        conn.rcptto_list ["friend@example.net", "nonexistent@example.net"]
+        assert_raise Net::SMTPMailboxPermanentlyUnavailable do
+          conn.rcptto_list ["friend@example.net", "nonexistent@example.net"]
+        end
       end
-      assert_empty @recipients
+      assert_equal ["friend@example.net"], @recipients
     end
 
     private

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -589,13 +589,23 @@ module Net
       end
     end
 
-    def test_rcpt_to_nonexistent_recipient
+    def test_rcpt_to_nonexistent_recipient_send_message
       port = fake_server_start
       smtp = Net::SMTP.new('localhost', port)
       smtp.start do |conn|
         assert_raise Net::SMTPMailboxPermanentlyUnavailable do
           conn.send_message "test", "me@example.org", ["nonexistent@example.net", "friend@example.net"]
         end
+      end
+      assert_empty @recipients
+    end
+
+    def test_rcpt_to_nonexistent_recipient_rcptto
+      port = fake_server_start
+      smtp = Net::SMTP.new('localhost', port)
+      smtp.start do |conn|
+        conn.mailfrom "me@example.org"
+        conn.rcptto_list ["friend@example.net", "nonexistent@example.net"]
       end
       assert_empty @recipients
     end

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -636,6 +636,18 @@ module Net
       assert_empty @recipients
     end
 
+    def test_rcptto_list_some_nonexistent_recipients
+      port = fake_server_start
+      smtp = Net::SMTP.new('localhost', port)
+      smtp.start do |conn|
+        conn.mailfrom "me@example.org"
+        assert_raise Net::SMTPMixedRecipientStatus do
+          conn.rcptto_list ["friend@example.net", "nonexistent1@example.net", "nonexistent2@example.net", "friend@example.com"] do end
+        end
+      end
+      assert_equal ["friend@example.net", "friend@example.com"], @recipients
+    end
+
     private
 
     def accept(servers)

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -639,6 +639,23 @@ module Net
             else
               sock.puts "535 5.7.8 Error: authentication failed: authentication failure\r\n"
             end
+          when /\AMAIL FROM: *<.*>/
+            sock.puts "250 2.1.0 Okay\r\n"
+          when /\ARCPT TO: *<(.*)>/
+            if $1.start_with? "-"
+              sock.puts "501 5.1.3 Bad recipient address syntax\r\n"
+            elsif $1.start_with? "~"
+              sock.puts "400 4.0.0 Try again\r\n"
+            else
+              sock.puts "250 2.1.5 Okay\r\n"
+            end
+          when "DATA"
+            sock.puts "354 Continue (finish with dot)\r\n"
+            loop do
+              line = sock.gets
+              break if line == ".\r\n"
+            end
+            sock.puts "250 2.6.0 Okay\r\n"
           when "QUIT"
             sock.puts "221 2.0.0 Bye\r\n"
             sock.close

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -560,7 +560,25 @@ module Net
       assert_equal('wrong number of arguments (given 5, expected 0..4)', err.message)
     end
 
-    def test_rcpt_to
+    def test_send_message_rcpt_to_string
+      port = fake_server_start
+      smtp = Net::SMTP.new('localhost', port)
+      smtp.start do |conn|
+        conn.send_message "test", "me@example.org", "you@example.net"
+      end
+      assert_equal %w[you@example.net], @recipients
+    end
+
+    def test_send_message_rcpt_to_single_list
+      port = fake_server_start
+      smtp = Net::SMTP.new('localhost', port)
+      smtp.start do |conn|
+        conn.send_message "test", "me@example.org", ["you@example.net"]
+      end
+      assert_equal %w[you@example.net], @recipients
+    end
+
+    def test_send_message_rcpt_to_two_of_them
       port = fake_server_start
       smtp = Net::SMTP.new('localhost', port)
       smtp.start do |conn|

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -577,6 +577,7 @@ module Net
 
     def fake_server_start(helo: 'localhost', user: nil, password: nil, tls: false, starttls: false, authtype: 'PLAIN')
       @starttls_started = false
+      @recipients = []
       servers = Socket.tcp_server_sockets('localhost', 0)
       @server_threads << Thread.start do
         Thread.current.abort_on_exception = true
@@ -648,6 +649,7 @@ module Net
             elsif $1.start_with? "~"
               sock.puts "400 4.0.0 Try again\r\n"
             else
+              @recipients << $1
               sock.puts "250 2.1.5 Okay\r\n"
             end
           when "DATA"

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -573,7 +573,9 @@ module Net
       port = fake_server_start
       smtp = Net::SMTP.new('localhost', port)
       smtp.start do |conn|
-        conn.send_message "test", "me@example.org", ["-you@example.net", "friend@example.net"]
+        assert_raise Net::SMTPSyntaxError do
+          conn.send_message "test", "me@example.org", ["you@example.net", "-friend@example.net"]
+        end
       end
     end
 

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -583,7 +583,9 @@ module Net
       port = fake_server_start
       smtp = Net::SMTP.new('localhost', port)
       smtp.start do |conn|
-        conn.send_message "test", "me@example.org", ["~you@example.net", "friend@example.net"]
+        assert_raise Net::SMTPServerBusy do
+          conn.send_message "test", "me@example.org", ["~you@example.net", "friend@example.net"]
+        end
       end
     end
 

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -579,6 +579,14 @@ module Net
       end
     end
 
+    def test_rcpt_to_temporary_failure_recipient
+      port = fake_server_start
+      smtp = Net::SMTP.new('localhost', port)
+      smtp.start do |conn|
+        conn.send_message "test", "me@example.org", ["~you@example.net", "friend@example.net"]
+      end
+    end
+
     private
 
     def accept(servers)

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -606,7 +606,7 @@ module Net
       smtp.start do |conn|
         conn.mailfrom "me@example.org"
         assert_raise Net::SMTPMailboxPermanentlyUnavailable do
-          conn.rcptto_list ["friend@example.net", "nonexistent@example.net"]
+          conn.rcptto_list ["friend@example.net", "nonexistent@example.net"] do end
         end
       end
       assert_equal ["friend@example.net"], @recipients
@@ -617,7 +617,7 @@ module Net
       smtp = Net::SMTP.new('localhost', port)
       smtp.start do |conn|
         conn.mailfrom "me@example.org"
-        conn.rcptto_list []
+        conn.rcptto_list [] do end
       end
       assert_equal [], @recipients
     end
@@ -627,7 +627,7 @@ module Net
       smtp = Net::SMTP.new('localhost', port)
       smtp.start do |conn|
         conn.mailfrom "me@example.org"
-        conn.rcptto_list ["nonexistent1@example.net", "nonexistent2@example.net"]
+        conn.rcptto_list ["nonexistent1@example.net", "nonexistent2@example.net"] do end
       end
       assert_equal [], @recipients
     end

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -612,6 +612,26 @@ module Net
       assert_equal ["friend@example.net"], @recipients
     end
 
+    def test_rcptto_list_empty_list
+      port = fake_server_start
+      smtp = Net::SMTP.new('localhost', port)
+      smtp.start do |conn|
+        conn.mailfrom "me@example.org"
+        conn.rcptto_list []
+      end
+      assert_equal [], @recipients
+    end
+
+    def test_rcptto_list_all_nonexistent_recipients
+      port = fake_server_start
+      smtp = Net::SMTP.new('localhost', port)
+      smtp.start do |conn|
+        conn.mailfrom "me@example.org"
+        conn.rcptto_list ["nonexistent1@example.net", "nonexistent2@example.net"]
+      end
+      assert_equal [], @recipients
+    end
+
     private
 
     def accept(servers)

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -589,7 +589,7 @@ module Net
       end
     end
 
-    def test_rcpt_to_nonexistent_recipient_send_message
+    def test_rcpt_to_one_nonexistent_recipient_send_message
       port = fake_server_start
       smtp = Net::SMTP.new('localhost', port)
       smtp.start do |conn|
@@ -597,7 +597,7 @@ module Net
           conn.send_message "test", "me@example.org", ["nonexistent@example.net", "friend@example.net"]
         end
       end
-      assert_empty @recipients
+      assert_equal ['friend@example.net'], @recipients
     end
 
     def test_rcpt_to_nonexistent_recipient_rcptto
@@ -621,7 +621,7 @@ module Net
           conn.rcptto_list [] do end
         end
       end
-      assert_equal [], @recipients
+      assert_empty @recipients
     end
 
     def test_rcptto_list_all_nonexistent_recipients
@@ -633,7 +633,7 @@ module Net
           conn.rcptto_list ["nonexistent1@example.net", "nonexistent2@example.net"] do end
         end
       end
-      assert_equal [], @recipients
+      assert_empty @recipients
     end
 
     private

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -560,6 +560,14 @@ module Net
       assert_equal('wrong number of arguments (given 5, expected 0..4)', err.message)
     end
 
+    def test_rcpt_to
+      port = fake_server_start
+      smtp = Net::SMTP.new('localhost', port)
+      smtp.start do |conn|
+        conn.send_message "test", "me@example.org", ["you@example.net", "friend@example.net"]
+      end
+    end
+
     private
 
     def accept(servers)

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -569,6 +569,14 @@ module Net
       assert_equal %w[you@example.net friend@example.net], @recipients
     end
 
+    def test_rcpt_to_bad_recipient
+      port = fake_server_start
+      smtp = Net::SMTP.new('localhost', port)
+      smtp.start do |conn|
+        conn.send_message "test", "me@example.org", ["-you@example.net", "friend@example.net"]
+      end
+    end
+
     private
 
     def accept(servers)

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -591,7 +591,7 @@ module Net
       port = fake_server_start
       smtp = Net::SMTP.new('localhost', port)
       smtp.start do |conn|
-        assert_raise Net::SMTPSyntaxError do
+        assert_raise Net::SMTPMixedRecipientStatus do
           conn.send_message "test", "me@example.org", ["you@example.net", "-friend@example.net"]
         end
       end
@@ -611,7 +611,7 @@ module Net
       port = fake_server_start
       smtp = Net::SMTP.new('localhost', port)
       smtp.start do |conn|
-        assert_raise Net::SMTPMailboxPermanentlyUnavailable do
+        assert_raise Net::SMTPMixedRecipientStatus do
           conn.send_message "test", "me@example.org", ["nonexistent@example.net", "friend@example.net"]
         end
       end
@@ -623,7 +623,7 @@ module Net
       smtp = Net::SMTP.new('localhost', port)
       smtp.start do |conn|
         conn.mailfrom "me@example.org"
-        assert_raise Net::SMTPMailboxPermanentlyUnavailable do
+        assert_raise Net::SMTPMixedRecipientStatus do
           conn.rcptto_list ["friend@example.net", "nonexistent@example.net"] do end
         end
       end
@@ -647,7 +647,7 @@ module Net
       smtp = Net::SMTP.new('localhost', port)
       smtp.start do |conn|
         conn.mailfrom "me@example.org"
-        assert_raise ArgumentError do
+        assert_raise Net::SMTPMailboxPermanentlyUnavailable do
           conn.rcptto_list ["nonexistent1@example.net", "nonexistent2@example.net"] do end
         end
       end

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -667,7 +667,7 @@ module Net
             if $1.start_with? "-"
               sock.puts "501 5.1.3 Bad recipient address syntax\r\n"
             elsif $1.start_with? "~"
-              sock.puts "400 4.0.0 Try again\r\n"
+              sock.puts "450 4.2.1 Try again\r\n"
             else
               @recipients << $1
               sock.puts "250 2.1.5 Okay\r\n"


### PR DESCRIPTION
Hi,

I've found an issue with the `rcptto_list` method in Net::SMTP. It attempts to protect against "unknown users", but only tests against 53x-class errors, which are authentication-related. Additionally, in the case of some acceptable recipients, but others returning 53x-class errors, the block would be yielded to before the exception is thrown, potentially sending messages to the accepted recipients.

This patch updates this library to be more robust against mixed SMTP statuses.

* A new exception, SMTPMailboxPermanentlyUnavailable, can be thrown from any method that accepts a recipient address. It is a subclass of SMTPFatalError.
* A new exception, SMTPMixedRecipientStatus, can be thrown from `rcptto_list`. It is a subclass of SMTPMailboxPermanentlyUnavailable.
* In the event of all recipients being rejected by the server, previous versions of this gem would raise an `ArgumentError` that was indistinguishable from providing 0 recipient addresses. Now it will raise a more specific SMTP error.
* These exceptions are thrown *before* the method yields to the block. This allows the caller to inspect the exception and determine whether or not to continue with the transaction, instead.