### PR TITLE
add Net::SMTP::Authenticator class and auth_* methods are separated from the Net::SMTP class.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # NEWS
 
+## Version 0.4.0
+
+*  add Net::SMTP::Authenticator class and auth_* methods are separated from the Net::SMTP class. <https://github.com/ruby/net-smtp/pull/53/files>
+
 ## Version 0.3.3 (2022-10-29)
 
 * No timeout library required <https://github.com/ruby/net-smtp/pull/44>

--- a/lib/net/smtp/auth_cram_md5.rb
+++ b/lib/net/smtp/auth_cram_md5.rb
@@ -1,0 +1,48 @@
+unless defined? OpenSSL
+  begin
+    require 'digest/md5'
+  rescue LoadError
+  end
+end
+
+class Net::SMTP
+  class AuthCramMD5 < Net::SMTP::Authenticator
+    auth_type :cram_md5
+
+    def auth(user, secret)
+      challenge = continue('AUTH CRAM-MD5')
+      crammed = cram_md5_response(secret, challenge.unpack1('m'))
+      finish(base64_encode("#{user} #{crammed}"))
+    end
+
+    IMASK = 0x36
+    OMASK = 0x5c
+
+    # CRAM-MD5: [RFC2195]
+    def cram_md5_response(secret, challenge)
+      tmp = digest_class::MD5.digest(cram_secret(secret, IMASK) + challenge)
+      digest_class::MD5.hexdigest(cram_secret(secret, OMASK) + tmp)
+    end
+
+    CRAM_BUFSIZE = 64
+
+    def cram_secret(secret, mask)
+      secret = digest_class::MD5.digest(secret) if secret.size > CRAM_BUFSIZE
+      buf = secret.ljust(CRAM_BUFSIZE, "\0")
+      0.upto(buf.size - 1) do |i|
+        buf[i] = (buf[i].ord ^ mask).chr
+      end
+      buf
+    end
+
+    def digest_class
+      @digest_class ||= if defined?(OpenSSL::Digest)
+                          OpenSSL::Digest
+                        elsif defined?(::Digest)
+                          ::Digest
+                        else
+                          raise '"openssl" or "digest" library is required'
+                        end
+    end
+  end
+end

--- a/lib/net/smtp/auth_loign.rb
+++ b/lib/net/smtp/auth_loign.rb
@@ -1,0 +1,11 @@
+class Net::SMTP
+  class AuthLogin < Net::SMTP::Authenticator
+    auth_type :login
+
+    def auth(user, secret)
+      continue('AUTH LOGIN')
+      continue(base64_encode(user))
+      finish(base64_encode(secret))
+    end
+  end
+end

--- a/lib/net/smtp/auth_plain.rb
+++ b/lib/net/smtp/auth_plain.rb
@@ -1,0 +1,9 @@
+class Net::SMTP
+  class AuthPlain < Net::SMTP::Authenticator
+    auth_type :plain
+
+    def auth(user, secret)
+      finish('AUTH PLAIN ' + base64_encode("\0#{user}\0#{secret}"))
+    end
+  end
+end

--- a/lib/net/smtp/authenticator.rb
+++ b/lib/net/smtp/authenticator.rb
@@ -1,0 +1,46 @@
+module Net
+  class SMTP
+    class Authenticator
+      def self.auth_classes
+        @classes ||= {}
+      end
+
+      def self.auth_type(type)
+        Authenticator.auth_classes[type] = self
+      end
+
+      def self.auth_class(type)
+        Authenticator.auth_classes[type.intern]
+      end
+
+      attr_reader :smtp
+
+      def initialize(smtp)
+        @smtp = smtp
+      end
+
+      # @param arg [String] message to server
+      # @return [String] message from server
+      def continue(arg)
+        res = smtp.get_response arg
+        raise res.exception_class.new(res) unless res.continue?
+        res.string.split[1]
+      end
+
+      # @param arg [String] message to server
+      # @return [Net::SMTP::Response] response from server
+      def finish(arg)
+        res = smtp.get_response arg
+        raise SMTPAuthenticationError.new(res) unless res.success?
+        res
+      end
+
+      # @param str [String]
+      # @return [String] Base64 encoded string
+      def base64_encode(str)
+        # expects "str" may not become too long
+        [str].pack('m0')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This allows you to add a new authentication method to Net::SMTP.
Create a class with an `auth` method that inherits Net::SMTP::Authenticator.
The `auth` method has two arguments, `user` and `secret`.
Send an instruction to the SMTP server by using the `continue` or `finish` method.
For more information, see lib/net/smtp/auto _*.rb.