### PR TITLE
Fixed issue sending emails to unaffected recipients on 53x error

### DIFF
--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -906,23 +906,10 @@ module Net
 
     def rcptto_list(to_addrs)
       raise ArgumentError, 'mail destination not given' if to_addrs.empty?
-      ok_users = []
-      unknown_users = []
       to_addrs.flatten.each do |addr|
-        begin
-          rcptto addr
-        rescue SMTPAuthenticationError
-          unknown_users << addr.to_s.dump
-        else
-          ok_users << addr
-        end
+        rcptto addr
       end
-      raise ArgumentError, 'mail destination not given' if ok_users.empty?
-      ret = yield
-      unless unknown_users.empty?
-        raise SMTPAuthenticationError, "failed to deliver for #{unknown_users.join(', ')}"
-      end
-      ret
+      yield
     end
 
     # +to_addr+ is +String+ or +Net::SMTP::Address+


### PR DESCRIPTION
When multiple recipients were specified and one recipient encountered a 53x error, despite an exception being raised, emails were being sent to the recipients that didn't encounter errors. This patch has been applied to handle 53x errors the same way as other errors.