### PR TITLE
remove SMTPUTF8RequiredError

### DIFF
--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -75,10 +75,6 @@ module Net
     include SMTPError
   end
 
-  # Represents a need to use SMTPUTF8 when the server does not support it
-  class SMTPUTF8RequiredError < SMTPUnsupportedCommand
-  end
-
   #
   # == What is This Library?
   #
@@ -760,7 +756,6 @@ module Net
     # * Net::SMTPServerBusy
     # * Net::SMTPSyntaxError
     # * Net::SMTPFatalError
-    # * Net::SMTPUTF8RequiredError
     # * Net::SMTPUnknownError
     # * Net::ReadTimeout
     # * IOError
@@ -816,7 +811,6 @@ module Net
     # * Net::SMTPServerBusy
     # * Net::SMTPSyntaxError
     # * Net::SMTPFatalError
-    # * Net::SMTPUTF8RequiredError
     # * Net::SMTPUnknownError
     # * Net::ReadTimeout
     # * IOError
@@ -893,8 +887,7 @@ module Net
 
     # +from_addr+ is +String+ or +Net::SMTP::Address+
     def mailfrom(from_addr)
-      addr = if requires_smtputf8(from_addr)
-               raise SMTPUTF8RequiredError, "Message requires SMTPUTF8 but server does not support that" unless capable? "SMTPUTF8"
+      addr = if requires_smtputf8(from_addr) && capable?("SMTPUTF8")
                Address.new(from_addr, "SMTPUTF8")
              else
                Address.new(from_addr)

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -547,9 +547,8 @@ module Net
     def test_send_smtputf_sender_without_server
       server = FakeServer.start(smtputf8: false)
       smtp = Net::SMTP.start 'localhost', server.port
-      assert_raise(Net::SMTPUTF8RequiredError) do
-        smtp.send_message('message', 'rené@example.com')
-      end
+      smtp.send_message('message', 'rené@example.com', 'foo@example.com')
+      assert server.commands.include? "MAIL FROM:<rené@example.com>\r\n"
     end
 
     def test_send_smtputf8_sender


### PR DESCRIPTION
Email addresses that contain non-ASCII characters no longer cause an error if the server does not support SMTPUTF8. This is because even if the server does not support SMTPUTF8, it may not cause an error for email addresses with non-ASCII characters. The server should decide whether to cause an error or not.