### PR TITLE
Make `#auth_capable?` public

### DIFF
--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -316,12 +316,13 @@ module Net
       auth_capable?('CRAM-MD5')
     end
 
+    # Returns whether the server advertises support for the authentication type.
+    # You cannot get valid result before opening SMTP session.
     def auth_capable?(type)
       return nil unless @capabilities
       return false unless @capabilities['AUTH']
       @capabilities['AUTH'].include?(type)
     end
-    private :auth_capable?
 
     # Returns supported authentication methods on this server.
     # You cannot get valid value before opening SMTP session.


### PR DESCRIPTION
This can be useful to users of the library, in the same way that `#capable?`, `#capabilities`, and `#capable_auth_types` are all useful.  For what it's worth `#auth_capable?` is public for [`net-imap` v0.4.0](https://ruby.github.io/net-imap/Net/IMAP.html#method-i-auth_capable-3F).

I will also suggest that perhaps some future version should deprecate (and eventually, remove) the specific mechanism predicate methods (`capable_plain_auth?`, `capable_login_auth?`, and `capable_cram_md5_auth?`).  A new predicate method shouldn't be added for every potential SASL mechanism.