### PR TITLE
Allow case-insensitive strings for SASL mechanism

### DIFF
--- a/lib/net/smtp/authenticator.rb
+++ b/lib/net/smtp/authenticator.rb
@@ -6,11 +6,13 @@ module Net
       end
 
       def self.auth_type(type)
+        type = type.to_s.upcase.tr(?_, ?-).to_sym
         Authenticator.auth_classes[type] = self
       end
 
       def self.auth_class(type)
-        Authenticator.auth_classes[type.intern]
+        type = type.to_s.upcase.tr(?_, ?-).to_sym
+        Authenticator.auth_classes[type]
       end
 
       attr_reader :smtp

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -485,7 +485,7 @@ module Net
       omit "openssl or digest library not loaded" unless defined? OpenSSL or defined? Digest
 
       port = fake_server_start(auth: 'CRAM-MD5')
-      Net::SMTP.start('localhost', port, user: 'account', password: 'password', authtype: :cram_md5){}
+      Net::SMTP.start('localhost', port, user: 'account', password: 'password', authtype: "CRAM-MD5"){}
 
       port = fake_server_start(auth: 'CRAM-MD5')
       assert_raise Net::SMTPAuthenticationError do


### PR DESCRIPTION
In particular, this erases the difference between `:scram_sha_256` (the Net::SMTP authtype) and "SCRAM-SHA-256" (the SASL mechanism) or `:cram_md5` and "CRAM-MD5".