### PR TITLE
Wrap `#authenticate` with `critical`

### DIFF
--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -835,7 +835,7 @@ module Net
       check_auth_method authtype
       check_auth_args user, secret
       authenticator = Authenticator.auth_class(authtype).new(self)
-      authenticator.auth(user, secret)
+      critical { authenticator.auth(user, secret) }
     end
 
     private


### PR DESCRIPTION
Is there a reason not to do this?  It seems to me that it might be needed to safely handle SASL mechanisms with multiple challenge/response cycles, right?