### PR TITLE
Remove unused private `auth_method`

### DIFF
--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -846,10 +846,6 @@ module Net
       end
     end
 
-    def auth_method(type)
-      "auth_#{type.to_s.downcase}".intern
-    end
-
     def check_auth_args(user, secret, authtype = DEFAULT_AUTH_TYPE)
       unless user
         raise ArgumentError, 'SMTP-AUTH requested but missing user name'


### PR DESCRIPTION
This private method is no longer referenced, since the 0.4.0 release.