### PR TITLE
Use a shared SASL implementation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
       engine: cruby
-      min_version: 2.6
+      min_version: 2.7
 
   build:
     needs: ruby-versions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,4 +31,4 @@ jobs:
     - name: Install dependencies
       run: bundle install
     - name: Run test
-      run: rake test
+      run: bundle exec rake test

--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -183,7 +183,7 @@ module Net
   #
   #     # PLAIN
   #     Net::SMTP.start('your.smtp.server', 25,
-  #                     user: 'Your Account', secret: 'Your Password', authtype: :plain)
+  #                     username: 'Your Account', secret: 'Your Password', authtype: :plain)
   #
   # Support for other SASL mechanisms-such as +EXTERNAL+, +OAUTHBEARER+,
   # +SCRAM-SHA-256+, and +XOAUTH2+-will be added in a future release.
@@ -460,15 +460,15 @@ module Net
     #
     # :call-seq:
     #  start(address, port = nil, helo: 'localhost', auth: nil, tls: false, starttls: :auto, tls_verify: true, tls_hostname: nil, ssl_context_params: nil) { |smtp| ... }
-    #  start(address, port = nil, helo: 'localhost', user: nil, secret: nil, authtype: nil, tls: false, starttls: :auto, tls_verify: true, tls_hostname: nil, ssl_context_params: nil) { |smtp| ... }
-    #  start(address, port = nil, helo = 'localhost', user = nil, secret = nil, authtype = nil) { |smtp| ... }
+    #  start(address, port = nil, helo: 'localhost', username: nil, secret: nil, authtype: nil, tls: false, starttls: :auto, tls_verify: true, tls_hostname: nil, ssl_context_params: nil) { |smtp| ... }
+    #  start(address, port = nil, helo = 'localhost', username = nil, secret = nil, authtype = nil) { |smtp| ... }
     #
     # Creates a new Net::SMTP object and connects to the server.
     #
     # This method is equivalent to:
     #
     #   Net::SMTP.new(address, port, tls_verify: flag, tls_hostname: hostname, ssl_context_params: nil)
-    #     .start(helo: helo_domain, user: account, secret: password, authtype: authtype)
+    #     .start(helo: helo_domain, username: account, secret: password, authtype: authtype)
     #
     # See also: Net::SMTP.new, #start
     #
@@ -515,7 +515,7 @@ module Net
     #
     # +authtype+ is the SASL authentication mechanism.
     #
-    # +user+ is the authentication or authorization identity.
+    # +username+ or +user+ is the authentication or authorization identity.
     #
     # +secret+ or +password+ is your password or other authentication token.
     #
@@ -541,17 +541,18 @@ module Net
     #
     def SMTP.start(address, port = nil, *args, helo: nil,
                    user: nil, secret: nil, password: nil, authtype: nil,
+                   username: nil,
                    auth: nil,
                    tls: false, starttls: :auto,
                    tls_verify: true, tls_hostname: nil, ssl_context_params: nil,
                    &block)
       raise ArgumentError, "wrong number of arguments (given #{args.size + 2}, expected 1..6)" if args.size > 4
       helo ||= args[0] || 'localhost'
-      user ||= args[1]
+      username ||= user || args[1]
       secret ||= password || args[2]
       authtype ||= args[3]
       new(address, port, tls: tls, starttls: starttls, tls_verify: tls_verify, tls_hostname: tls_hostname, ssl_context_params: ssl_context_params)
-        .start(helo: helo, user: user, secret: secret, authtype: authtype, auth: auth, &block)
+        .start(helo: helo, username: username, secret: secret, authtype: authtype, auth: auth, &block)
     end
 
     # +true+ if the \SMTP session has been started.
@@ -561,8 +562,8 @@ module Net
 
     #
     # :call-seq:
-    #  start(helo: 'localhost', user: nil, secret: nil, authtype: nil) { |smtp| ... }
-    #  start(helo = 'localhost', user = nil, secret = nil, authtype = nil) { |smtp| ... }
+    #  start(helo: 'localhost', username: nil, secret: nil, authtype: nil) { |smtp| ... }
+    #  start(helo = 'localhost', username = nil, secret = nil, authtype = nil) { |smtp| ... }
     #  start(helo = 'localhost', auth: {type: nil, **auth_kwargs}) { |smtp| ... }
     #
     # Opens a TCP connection and starts the SMTP session.
@@ -577,7 +578,7 @@ module Net
     #
     # +authtype+ is the SASL authentication mechanism.
     #
-    # +user+ is the authentication or authorization identity.
+    # +username+ or +user+ is the authentication or authorization identity.
     #
     # +secret+ or +password+ is your password or other authentication token.
     #
@@ -603,7 +604,7 @@ module Net
     #
     #     require 'net/smtp'
     #     smtp = Net::SMTP.new('smtp.mail.server', 25)
-    #     smtp.start(helo: helo_domain, user: account, secret: password, authtype: authtype) do |smtp|
+    #     smtp.start(helo: helo_domain, username: account, secret: password, authtype: authtype) do |smtp|
     #       smtp.send_message msgstr, 'from@example.com', ['dest@example.com']
     #     end
     #
@@ -628,11 +629,11 @@ module Net
     # * IOError
     #
     def start(*args, helo: nil,
-              user: nil, secret: nil, password: nil,
+              user: nil, username: nil, secret: nil, password: nil,
               authtype: nil, auth: nil)
       raise ArgumentError, "wrong number of arguments (given #{args.size}, expected 0..4)" if args.size > 4
       helo ||= args[0] || 'localhost'
-      user ||= args[1]
+      username ||= user || args[1]
       secret ||= password || args[2]
       authtype ||= args[3]
       auth ||= {}
@@ -650,13 +651,13 @@ module Net
       end
       if block_given?
         begin
-          do_start helo, user, secret, authtype, **auth
+          do_start helo, username, secret, authtype, **auth
           return yield(self)
         ensure
           do_finish
         end
       else
-        do_start helo, user, secret, authtype, **auth
+        do_start helo, username, secret, authtype, **auth
         return self
       end
     end
@@ -882,12 +883,12 @@ module Net
     # +authtype+ is the name of a SASL authentication mechanism.
     #
     # All arguments-other than +authtype+-are forwarded to the authenticator.
-    # Different authenticators may interpret the +user+ and +secret+
+    # Different authenticators may interpret the +username+ and +secret+
     # arguments differently.
-    def authenticate(user, secret, authtype = DEFAULT_AUTH_TYPE, **kwargs, &block)
-      check_auth_args authtype, user, secret, **kwargs
+    def authenticate(username, secret, authtype = DEFAULT_AUTH_TYPE, **kwargs, &block)
+      check_auth_args authtype, username, secret, **kwargs
       authenticator = Authenticator.auth_class(authtype).new(self)
-      authenticator.auth(user, secret, **kwargs, &block)
+      authenticator.auth(username, secret, **kwargs, &block)
     end
 
     private

--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -878,6 +878,10 @@ module Net
 
     DEFAULT_AUTH_TYPE = :plain
 
+    # call-seq:
+    #   authenticate(authtype = DEFAULT_AUTH_TYPE, **, &)
+    #   authenticate(username, secret, authtype = DEFAULT_AUTH_TYPE, **, &)
+    #
     # Authenticates with the server, using the "AUTH" command.
     #
     # +authtype+ is the name of a SASL authentication mechanism.
@@ -885,10 +889,17 @@ module Net
     # All arguments-other than +authtype+-are forwarded to the authenticator.
     # Different authenticators may interpret the +username+ and +secret+
     # arguments differently.
-    def authenticate(username, secret, authtype = DEFAULT_AUTH_TYPE, **kwargs, &block)
-      check_auth_args authtype, username, secret, **kwargs
+    def authenticate(*args, **kwargs, &block)
+      case args.length
+      when 1, 3 then authtype = args.pop
+      when (4..)
+        raise ArgumentError, "wrong number of arguments " \
+                             "(given %d, expected 0..3)" % [args.length]
+      end
+      authtype ||= DEFAULT_AUTH_TYPE
+      check_auth_args authtype, *args, **kwargs
       authenticator = Authenticator.auth_class(authtype).new(self)
-      authenticator.auth(username, secret, **kwargs, &block)
+      authenticator.auth(*args, **kwargs, &block)
     end
 
     private

--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -869,10 +869,10 @@ module Net
     # All arguments-other than +authtype+-are forwarded to the authenticator.
     # Different authenticators may interpret the +user+ and +secret+
     # arguments differently.
-    def authenticate(user, secret, authtype = DEFAULT_AUTH_TYPE)
-      check_auth_args authtype, user, secret
+    def authenticate(user, secret, authtype = DEFAULT_AUTH_TYPE, **kwargs, &block)
+      check_auth_args authtype, user, secret, **kwargs
       authenticator = Authenticator.auth_class(authtype).new(self)
-      authenticator.auth(user, secret)
+      authenticator.auth(user, secret, **kwargs, &block)
     end
 
     private

--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -879,12 +879,14 @@ module Net
     DEFAULT_AUTH_TYPE = :plain
 
     # call-seq:
-    #   authenticate(authtype = DEFAULT_AUTH_TYPE, **, &)
-    #   authenticate(username, secret, authtype = DEFAULT_AUTH_TYPE, **, &)
+    #   authenticate(type: DEFAULT_AUTH_TYPE, **, &)
+    #   authenticate(type = DEFAULT_AUTH_TYPE, **, &)
+    #   authenticate(username, secret, type: DEFAULT_AUTH_TYPE, **, &)
+    #   authenticate(username, secret, type = DEFAULT_AUTH_TYPE, **, &)
     #
     # Authenticates with the server, using the "AUTH" command.
     #
-    # +authtype+ is the name of a SASL authentication mechanism.
+    # +type+ is the name of a SASL authentication mechanism.
     #
     # All arguments-other than +authtype+-are forwarded to the authenticator.
     # Different authenticators may interpret the +username+ and +secret+
@@ -896,19 +898,19 @@ module Net
         raise ArgumentError, "wrong number of arguments " \
                              "(given %d, expected 0..3)" % [args.length]
       end
-      authtype ||= DEFAULT_AUTH_TYPE
-      check_auth_args authtype, *args, **kwargs
+      authtype, args, kwargs = check_auth_args authtype, *args, **kwargs
       authenticator = Authenticator.auth_class(authtype).new(self)
       authenticator.auth(*args, **kwargs, &block)
     end
 
     private
 
-    def check_auth_args(type, *args, **kwargs)
-      type ||= DEFAULT_AUTH_TYPE
+    def check_auth_args(type_arg = nil, *args, type: nil, **kwargs)
+      type ||= type_arg || DEFAULT_AUTH_TYPE
       klass = Authenticator.auth_class(type) or
         raise ArgumentError, "wrong authentication type #{type}"
       klass.check_args(*args, **kwargs)
+      [type, args, kwargs]
     end
 
     #

--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -898,6 +898,22 @@ module Net
         raise ArgumentError, "wrong number of arguments " \
                              "(given %d, expected 0..3)" % [args.length]
       end
+      auth(authtype, *args, **kwargs, &block)
+    end
+
+    # call-seq:
+    #   auth(type = DEFAULT_AUTH_TYPE, ...)
+    #   auth(type: DEFAULT_AUTH_TYPE, **kwargs, &block)
+    #
+    # All arguments besides +mechanism+ are forwarded directly to the
+    # authenticator.  Alternatively, +mechanism+ can be provided by the +type+
+    # keyword parameter.  Positional parameters cannot be used with +type+.
+    #
+    # Different authenticators take different options, but common options
+    # include +authcid+ for authentication identity, +authzid+ for authorization
+    # identity, +username+ for either "authentication identity" or
+    # "authorization identity" depending on the +mechanism+, and +password+.
+    def auth(authtype = DEFAULT_AUTH_TYPE, *args, **kwargs, &block)
       authtype, args, kwargs = check_auth_args authtype, *args, **kwargs
       authenticator = Authenticator.auth_class(authtype).new(self)
       authenticator.auth(*args, **kwargs, &block)

--- a/lib/net/smtp/auth_cram_md5.rb
+++ b/lib/net/smtp/auth_cram_md5.rb
@@ -9,7 +9,12 @@ class Net::SMTP
   class AuthCramMD5 < Net::SMTP::Authenticator
     auth_type :cram_md5
 
-    def auth(user, secret)
+    def auth(user_arg = nil, secret_arg = nil,
+             authcid: nil, username: nil, user: nil,
+             secret: nil, password: nil,
+             **)
+      user   = req_param authcid, username, user, user_arg, "username (authcid)"
+      secret = req_param password, secret, secret_arg,      "secret (password)"
       challenge = continue('AUTH CRAM-MD5')
       crammed = cram_md5_response(secret, challenge.unpack1('m'))
       finish(base64_encode("#{user} #{crammed}"))

--- a/lib/net/smtp/auth_login.rb
+++ b/lib/net/smtp/auth_login.rb
@@ -2,7 +2,12 @@ class Net::SMTP
   class AuthLogin < Net::SMTP::Authenticator
     auth_type :login
 
-    def auth(user, secret)
+    def auth(user_arg = nil, secret_arg = nil,
+             authcid: nil, username: nil, user: nil,
+             secret: nil, password: nil,
+             **)
+      user   = req_param authcid, username, user, user_arg, "username (authcid)"
+      secret = req_param password, secret, secret_arg,      "secret (password)"
       continue('AUTH LOGIN')
       continue(base64_encode(user))
       finish(base64_encode(secret))

--- a/lib/net/smtp/auth_plain.rb
+++ b/lib/net/smtp/auth_plain.rb
@@ -2,7 +2,12 @@ class Net::SMTP
   class AuthPlain < Net::SMTP::Authenticator
     auth_type :plain
 
-    def auth(user, secret)
+    def auth(user_arg = nil, secret_arg = nil,
+             authcid: nil, username: nil, user: nil,
+             secret: nil, password: nil,
+             **)
+      user   = req_param authcid, username, user, user_arg, "username (authcid)"
+      secret = req_param password, secret, secret_arg,      "secret (password)"
       finish('AUTH PLAIN ' + base64_encode("\0#{user}\0#{secret}"))
     end
   end

--- a/lib/net/smtp/auth_sasl_client_adapter.rb
+++ b/lib/net/smtp/auth_sasl_client_adapter.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "net/imap"
+
+module Net
+  class SMTP
+    SASL = Net::IMAP::SASL
+
+    # Experimental
+    #
+    # Initialize with a block that runs a command, yielding for continuations.
+    class SASLClientAdapter < SASL::ClientAdapter
+      include SASL::ProtocolAdapters::SMTP
+
+      RESPONSE_ERRORS = [
+        SMTPAuthenticationError,
+        SMTPServerBusy,
+        SMTPSyntaxError,
+        SMTPFatalError,
+      ].freeze
+
+      def initialize(...)
+        super
+        @command_proc ||= client.method(:send_command_with_continuations)
+      end
+
+      def authenticate(...)
+        super
+      rescue SMTPServerBusy, SMTPSyntaxError, SMTPFatalError => error
+        raise SMTPAuthenticationError.new(error.response)
+      rescue SASL::AuthenticationIncomplete => error
+        raise error.response.exception_class.new(error.response)
+      end
+
+      def host;               client.address    end
+      def response_errors;    RESPONSE_ERRORS   end
+      def sasl_ir_capable?;   true              end
+      def drop_connection;    client.finish     end
+      def drop_connection!;   client.finish     end
+    end
+  end
+end

--- a/lib/net/smtp/auth_sasl_compatibility_adapter.rb
+++ b/lib/net/smtp/auth_sasl_compatibility_adapter.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Net
+  class SMTP
+
+    # Curries arguments to SASLAdapter.authenticate.
+    class AuthSASLCompatibilityAdapter
+      def initialize(mechanism) @mechanism = mechanism end
+      def check_args(...) SASL.authenticator(@mechanism, ...) end
+      def new(smtp) @sasl_adapter = SASLClientAdapter.new(smtp); self end
+      def auth(...) @sasl_adapter.authenticate(@mechanism, ...) end
+    end
+
+    Authenticator.auth_classes.default_proc = ->hash, mechanism {
+      hash[mechanism] = AuthSASLCompatibilityAdapter.new(mechanism)
+    }
+
+  end
+end

--- a/lib/net/smtp/authenticator.rb
+++ b/lib/net/smtp/authenticator.rb
@@ -15,11 +15,14 @@ module Net
         Authenticator.auth_classes[type]
       end
 
-      def self.check_args(user_arg = nil, secret_arg = nil, *, **)
-        unless user_arg
+      def self.check_args(user_arg = nil, secret_arg = nil, *,
+                          authcid: nil, username: nil, user: nil,
+                          secret: nil, password: nil,
+                          **)
+        unless authcid || username || user || user_arg
           raise ArgumentError, 'SMTP-AUTH requested but missing user name'
         end
-        unless secret_arg
+        unless password || secret || secret_arg
           raise ArgumentError, 'SMTP-AUTH requested but missing secret phrase'
         end
       end
@@ -52,6 +55,12 @@ module Net
         # expects "str" may not become too long
         [str].pack('m0')
       end
+
+      def req_param(*args, name)
+        args.compact.first or
+          raise ArgumentError, "SMTP-AUTH requested but missing #{name}"
+      end
+
     end
   end
 end

--- a/net-smtp.gemspec
+++ b/net-smtp.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{Simple Mail Transfer Protocol client library for Ruby.}
   spec.homepage      = "https://github.com/ruby/net-smtp"
   spec.licenses      = ["Ruby", "BSD-2-Clause"]
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 2.7.3"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage

--- a/net-smtp.gemspec
+++ b/net-smtp.gemspec
@@ -28,4 +28,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "net-protocol"
+
+  spec.add_dependency "net-imap", ">= 0.4.2" # experimental SASL support
 end

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -545,16 +545,6 @@ module Net
       assert_raise Net::SMTPAuthenticationError do
         Net::SMTP.start('localhost', port, user: 'account', password: 'password', authtype: :cram_md5){}
       end
-
-      port = fake_server_start(auth: 'CRAM-MD5')
-      smtp = Net::SMTP.new('localhost', port)
-      auth_cram_md5 = Net::SMTP::AuthCramMD5.new(smtp)
-      auth_cram_md5.define_singleton_method(:digest_class) { raise '"openssl" or "digest" library is required' }
-      Net::SMTP::AuthCramMD5.define_singleton_method(:new) { |_| auth_cram_md5 }
-      e = assert_raise RuntimeError do
-        smtp.start(user: 'account', password: 'password', authtype: :cram_md5){}
-      end
-      assert_equal('"openssl" or "digest" library is required', e.message)
     end
 
     def test_start_instance

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -471,6 +471,15 @@ module Net
       Net::SMTP.start('localhost', port, user: 'account', password: 'password', authtype: :plain){}
 
       port = fake_server_start(auth: 'plain')
+      Net::SMTP.start('localhost', port, authtype: "PLAIN",
+                      auth: {username: 'account', password: 'password'}){}
+
+      port = fake_server_start(auth: 'plain')
+      Net::SMTP.start('localhost', port, auth: {username: 'account',
+                                                password: 'password',
+                                                type: :plain}){}
+
+      port = fake_server_start(auth: 'plain')
       assert_raise Net::SMTPAuthenticationError do
         Net::SMTP.start('localhost', port, user: 'account', password: 'invalid', authtype: :plain){}
       end

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -110,6 +110,21 @@ module Net
       smtp = Net::SMTP.start 'localhost', server.port
       assert smtp.authenticate("account", "password", :plain).success?
       assert_equal "AUTH PLAIN AGFjY291bnQAcGFzc3dvcmQ=\r\n", server.commands.last
+
+      server = FakeServer.start(auth: 'plain')
+      smtp = Net::SMTP.start 'localhost', server.port
+      assert smtp.auth("PLAIN", "account", "password").success?
+      assert_equal "AUTH PLAIN AGFjY291bnQAcGFzc3dvcmQ=\r\n", server.commands.last
+
+      server = FakeServer.start(auth: 'plain')
+      smtp = Net::SMTP.start 'localhost', server.port
+      assert smtp.auth(type: "PLAIN", username: "account", secret: "password").success?
+      assert_equal "AUTH PLAIN AGFjY291bnQAcGFzc3dvcmQ=\r\n", server.commands.last
+
+      server = FakeServer.start(auth: 'plain')
+      smtp = Net::SMTP.start 'localhost', server.port
+      assert smtp.auth("PLAIN", username: "account", password: "password").success?
+      assert_equal "AUTH PLAIN AGFjY291bnQAcGFzc3dvcmQ=\r\n", server.commands.last
     end
 
     def test_unsuccessful_auth_plain
@@ -120,10 +135,20 @@ module Net
       assert_equal "535", err.response.status
     end
 
+    def test_auth_cram_md5
+      server = FakeServer.start(auth: 'CRAM-MD5')
+      smtp = Net::SMTP.start 'localhost', server.port
+      assert smtp.auth(:cram_md5, "account", password: "password").success?
+    end
+
     def test_auth_login
       server = FakeServer.start(auth: 'login')
       smtp = Net::SMTP.start 'localhost', server.port
       assert smtp.authenticate("account", "password", :login).success?
+
+      server = FakeServer.start(auth: 'login')
+      smtp = Net::SMTP.start 'localhost', server.port
+      assert smtp.auth("LOGIN", username: "account", secret: "password").success?
     end
 
     def test_unsuccessful_auth_login


### PR DESCRIPTION
Builds on the following other PRs:
* #68 
  * #63
  * #64 
  * #71
    * ~#65~
    * #72 
      * #66 
    * #73
      * #67

As currently written, this also depends on the following `net-imap` PRs:
* ruby/net-imap#183
* ruby/net-imap#187
* ruby/net-imap#195

After those PRs are applied, this PR creates an adapter that is compatible with `Authenticator` and `#authenticate` and registers it as a generic default for mechanisms that haven't otherwise been added (as subclasses of `Authenticator`).  This adapter then delegates to `net-imap`'s SASL implementation.  Every other mechanism supported by `net-imap` v0.4.1 is added here:
* `ANONYMOUS`
* `DIGEST-MD5` _(deprecated)_
* `EXTERNAL`
* `OAUTHBEARER`
* `SCRAM-SHA-1` and `SCRAM-SHA-256`
* `XOAUTH`

**TODO:** _Ideally, `net-smtp` and `net-imap` should both depend on a shared `sasl` or `net-sasl` gem, rather than keep the SASL implementation inside one or the other.  See https://github.com/ruby/net-imap/issues/23._

In this PR, the current `Net::SMTP::Authenticator` implementation is still used by the `PLAIN`, `LOGIN`, and `CRAM-MD5` mechanisms.  PR #70 removes the current authenticators are replaces them with this.

Related issues:
* Fixes #36 
* Fixes #46