### PR TITLE
Support keyword parameters for authenticators

### DIFF
--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -183,7 +183,7 @@ module Net
   #
   #     # PLAIN
   #     Net::SMTP.start('your.smtp.server', 25,
-  #                     user: 'Your Account', secret: 'Your Password', authtype: :plain)
+  #                     username: 'Your Account', secret: 'Your Password', authtype: :plain)
   #
   # Support for other SASL mechanisms-such as +EXTERNAL+, +OAUTHBEARER+,
   # +SCRAM-SHA-256+, and +XOAUTH2+-will be added in a future release.
@@ -460,15 +460,15 @@ module Net
     #
     # :call-seq:
     #  start(address, port = nil, helo: 'localhost', auth: nil, tls: false, starttls: :auto, tls_verify: true, tls_hostname: nil, ssl_context_params: nil) { |smtp| ... }
-    #  start(address, port = nil, helo: 'localhost', user: nil, secret: nil, authtype: nil, tls: false, starttls: :auto, tls_verify: true, tls_hostname: nil, ssl_context_params: nil) { |smtp| ... }
-    #  start(address, port = nil, helo = 'localhost', user = nil, secret = nil, authtype = nil) { |smtp| ... }
+    #  start(address, port = nil, helo: 'localhost', username: nil, secret: nil, authtype: nil, tls: false, starttls: :auto, tls_verify: true, tls_hostname: nil, ssl_context_params: nil) { |smtp| ... }
+    #  start(address, port = nil, helo = 'localhost', username = nil, secret = nil, authtype = nil) { |smtp| ... }
     #
     # Creates a new Net::SMTP object and connects to the server.
     #
     # This method is equivalent to:
     #
     #   Net::SMTP.new(address, port, tls_verify: flag, tls_hostname: hostname, ssl_context_params: nil)
-    #     .start(helo: helo_domain, user: account, secret: password, authtype: authtype)
+    #     .start(helo: helo_domain, username: account, secret: password, authtype: authtype)
     #
     # See also: Net::SMTP.new, #start
     #
@@ -515,7 +515,7 @@ module Net
     #
     # +authtype+ is the SASL authentication mechanism.
     #
-    # +user+ is the authentication or authorization identity.
+    # +username+ or +user+ is the authentication or authorization identity.
     #
     # +secret+ or +password+ is your password or other authentication token.
     #
@@ -541,17 +541,18 @@ module Net
     #
     def SMTP.start(address, port = nil, *args, helo: nil,
                    user: nil, secret: nil, password: nil, authtype: nil,
+                   username: nil,
                    auth: nil,
                    tls: false, starttls: :auto,
                    tls_verify: true, tls_hostname: nil, ssl_context_params: nil,
                    &block)
       raise ArgumentError, "wrong number of arguments (given #{args.size + 2}, expected 1..6)" if args.size > 4
       helo ||= args[0] || 'localhost'
-      user ||= args[1]
+      username ||= user || args[1]
       secret ||= password || args[2]
       authtype ||= args[3]
       new(address, port, tls: tls, starttls: starttls, tls_verify: tls_verify, tls_hostname: tls_hostname, ssl_context_params: ssl_context_params)
-        .start(helo: helo, user: user, secret: secret, authtype: authtype, auth: auth, &block)
+        .start(helo: helo, username: username, secret: secret, authtype: authtype, auth: auth, &block)
     end
 
     # +true+ if the \SMTP session has been started.
@@ -561,8 +562,8 @@ module Net
 
     #
     # :call-seq:
-    #  start(helo: 'localhost', user: nil, secret: nil, authtype: nil) { |smtp| ... }
-    #  start(helo = 'localhost', user = nil, secret = nil, authtype = nil) { |smtp| ... }
+    #  start(helo: 'localhost', username: nil, secret: nil, authtype: nil) { |smtp| ... }
+    #  start(helo = 'localhost', username = nil, secret = nil, authtype = nil) { |smtp| ... }
     #  start(helo = 'localhost', auth: {type: nil, **auth_kwargs}) { |smtp| ... }
     #
     # Opens a TCP connection and starts the SMTP session.
@@ -577,7 +578,7 @@ module Net
     #
     # +authtype+ is the SASL authentication mechanism.
     #
-    # +user+ is the authentication or authorization identity.
+    # +username+ or +user+ is the authentication or authorization identity.
     #
     # +secret+ or +password+ is your password or other authentication token.
     #
@@ -603,7 +604,7 @@ module Net
     #
     #     require 'net/smtp'
     #     smtp = Net::SMTP.new('smtp.mail.server', 25)
-    #     smtp.start(helo: helo_domain, user: account, secret: password, authtype: authtype) do |smtp|
+    #     smtp.start(helo: helo_domain, username: account, secret: password, authtype: authtype) do |smtp|
     #       smtp.send_message msgstr, 'from@example.com', ['dest@example.com']
     #     end
     #
@@ -628,11 +629,11 @@ module Net
     # * IOError
     #
     def start(*args, helo: nil,
-              user: nil, secret: nil, password: nil,
+              user: nil, username: nil, secret: nil, password: nil,
               authtype: nil, auth: nil)
       raise ArgumentError, "wrong number of arguments (given #{args.size}, expected 0..4)" if args.size > 4
       helo ||= args[0] || 'localhost'
-      user ||= args[1]
+      username ||= user || args[1]
       secret ||= password || args[2]
       authtype ||= args[3]
       auth ||= {}
@@ -650,13 +651,13 @@ module Net
       end
       if block_given?
         begin
-          do_start helo, user, secret, authtype, **auth
+          do_start helo, username, secret, authtype, **auth
           return yield(self)
         ensure
           do_finish
         end
       else
-        do_start helo, user, secret, authtype, **auth
+        do_start helo, username, secret, authtype, **auth
         return self
       end
     end
@@ -882,12 +883,12 @@ module Net
     # +authtype+ is the name of a SASL authentication mechanism.
     #
     # All arguments-other than +authtype+-are forwarded to the authenticator.
-    # Different authenticators may interpret the +user+ and +secret+
+    # Different authenticators may interpret the +username+ and +secret+
     # arguments differently.
-    def authenticate(user, secret, authtype = DEFAULT_AUTH_TYPE, **kwargs, &block)
-      check_auth_args authtype, user, secret, **kwargs
+    def authenticate(username, secret, authtype = DEFAULT_AUTH_TYPE, **kwargs, &block)
+      check_auth_args authtype, username, secret, **kwargs
       authenticator = Authenticator.auth_class(authtype).new(self)
-      authenticator.auth(user, secret, **kwargs, &block)
+      authenticator.auth(username, secret, **kwargs, &block)
     end
 
     private

--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -878,6 +878,10 @@ module Net
 
     DEFAULT_AUTH_TYPE = :plain
 
+    # call-seq:
+    #   authenticate(authtype = DEFAULT_AUTH_TYPE, **, &)
+    #   authenticate(username, secret, authtype = DEFAULT_AUTH_TYPE, **, &)
+    #
     # Authenticates with the server, using the "AUTH" command.
     #
     # +authtype+ is the name of a SASL authentication mechanism.
@@ -885,10 +889,17 @@ module Net
     # All arguments-other than +authtype+-are forwarded to the authenticator.
     # Different authenticators may interpret the +username+ and +secret+
     # arguments differently.
-    def authenticate(username, secret, authtype = DEFAULT_AUTH_TYPE, **kwargs, &block)
-      check_auth_args authtype, username, secret, **kwargs
+    def authenticate(*args, **kwargs, &block)
+      case args.length
+      when 1, 3 then authtype = args.pop
+      when (4..)
+        raise ArgumentError, "wrong number of arguments " \
+                             "(given %d, expected 0..3)" % [args.length]
+      end
+      authtype ||= DEFAULT_AUTH_TYPE
+      check_auth_args authtype, *args, **kwargs
       authenticator = Authenticator.auth_class(authtype).new(self)
-      authenticator.auth(username, secret, **kwargs, &block)
+      authenticator.auth(*args, **kwargs, &block)
     end
 
     private

--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -869,10 +869,10 @@ module Net
     # All arguments-other than +authtype+-are forwarded to the authenticator.
     # Different authenticators may interpret the +user+ and +secret+
     # arguments differently.
-    def authenticate(user, secret, authtype = DEFAULT_AUTH_TYPE)
-      check_auth_args authtype, user, secret
+    def authenticate(user, secret, authtype = DEFAULT_AUTH_TYPE, **kwargs, &block)
+      check_auth_args authtype, user, secret, **kwargs
       authenticator = Authenticator.auth_class(authtype).new(self)
-      authenticator.auth(user, secret)
+      authenticator.auth(user, secret, **kwargs, &block)
     end
 
     private

--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -879,12 +879,14 @@ module Net
     DEFAULT_AUTH_TYPE = :plain
 
     # call-seq:
-    #   authenticate(authtype = DEFAULT_AUTH_TYPE, **, &)
-    #   authenticate(username, secret, authtype = DEFAULT_AUTH_TYPE, **, &)
+    #   authenticate(type: DEFAULT_AUTH_TYPE, **, &)
+    #   authenticate(type = DEFAULT_AUTH_TYPE, **, &)
+    #   authenticate(username, secret, type: DEFAULT_AUTH_TYPE, **, &)
+    #   authenticate(username, secret, type = DEFAULT_AUTH_TYPE, **, &)
     #
     # Authenticates with the server, using the "AUTH" command.
     #
-    # +authtype+ is the name of a SASL authentication mechanism.
+    # +type+ is the name of a SASL authentication mechanism.
     #
     # All arguments-other than +authtype+-are forwarded to the authenticator.
     # Different authenticators may interpret the +username+ and +secret+
@@ -896,19 +898,19 @@ module Net
         raise ArgumentError, "wrong number of arguments " \
                              "(given %d, expected 0..3)" % [args.length]
       end
-      authtype ||= DEFAULT_AUTH_TYPE
-      check_auth_args authtype, *args, **kwargs
+      authtype, args, kwargs = check_auth_args authtype, *args, **kwargs
       authenticator = Authenticator.auth_class(authtype).new(self)
       authenticator.auth(*args, **kwargs, &block)
     end
 
     private
 
-    def check_auth_args(type, *args, **kwargs)
-      type ||= DEFAULT_AUTH_TYPE
+    def check_auth_args(type_arg = nil, *args, type: nil, **kwargs)
+      type ||= type_arg || DEFAULT_AUTH_TYPE
       klass = Authenticator.auth_class(type) or
         raise ArgumentError, "wrong authentication type #{type}"
       klass.check_args(*args, **kwargs)
+      [type, args, kwargs]
     end
 
     #

--- a/lib/net/smtp/auth_cram_md5.rb
+++ b/lib/net/smtp/auth_cram_md5.rb
@@ -9,7 +9,12 @@ class Net::SMTP
   class AuthCramMD5 < Net::SMTP::Authenticator
     auth_type :cram_md5
 
-    def auth(user, secret)
+    def auth(user_arg = nil, secret_arg = nil,
+             authcid: nil, username: nil, user: nil,
+             secret: nil, password: nil,
+             **)
+      user   = req_param authcid, username, user, user_arg, "username (authcid)"
+      secret = req_param password, secret, secret_arg,      "secret (password)"
       challenge = continue('AUTH CRAM-MD5')
       crammed = cram_md5_response(secret, challenge.unpack1('m'))
       finish(base64_encode("#{user} #{crammed}"))

--- a/lib/net/smtp/auth_login.rb
+++ b/lib/net/smtp/auth_login.rb
@@ -2,7 +2,12 @@ class Net::SMTP
   class AuthLogin < Net::SMTP::Authenticator
     auth_type :login
 
-    def auth(user, secret)
+    def auth(user_arg = nil, secret_arg = nil,
+             authcid: nil, username: nil, user: nil,
+             secret: nil, password: nil,
+             **)
+      user   = req_param authcid, username, user, user_arg, "username (authcid)"
+      secret = req_param password, secret, secret_arg,      "secret (password)"
       continue('AUTH LOGIN')
       continue(base64_encode(user))
       finish(base64_encode(secret))

--- a/lib/net/smtp/auth_plain.rb
+++ b/lib/net/smtp/auth_plain.rb
@@ -2,7 +2,12 @@ class Net::SMTP
   class AuthPlain < Net::SMTP::Authenticator
     auth_type :plain
 
-    def auth(user, secret)
+    def auth(user_arg = nil, secret_arg = nil,
+             authcid: nil, username: nil, user: nil,
+             secret: nil, password: nil,
+             **)
+      user   = req_param authcid, username, user, user_arg, "username (authcid)"
+      secret = req_param password, secret, secret_arg,      "secret (password)"
       finish('AUTH PLAIN ' + base64_encode("\0#{user}\0#{secret}"))
     end
   end

--- a/lib/net/smtp/authenticator.rb
+++ b/lib/net/smtp/authenticator.rb
@@ -15,11 +15,14 @@ module Net
         Authenticator.auth_classes[type]
       end
 
-      def self.check_args(user_arg = nil, secret_arg = nil, *, **)
-        unless user_arg
+      def self.check_args(user_arg = nil, secret_arg = nil, *,
+                          authcid: nil, username: nil, user: nil,
+                          secret: nil, password: nil,
+                          **)
+        unless authcid || username || user || user_arg
           raise ArgumentError, 'SMTP-AUTH requested but missing user name'
         end
-        unless secret_arg
+        unless password || secret || secret_arg
           raise ArgumentError, 'SMTP-AUTH requested but missing secret phrase'
         end
       end
@@ -52,6 +55,12 @@ module Net
         # expects "str" may not become too long
         [str].pack('m0')
       end
+
+      def req_param(*args, name)
+        args.compact.first or
+          raise ArgumentError, "SMTP-AUTH requested but missing #{name}"
+      end
+
     end
   end
 end

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -471,6 +471,15 @@ module Net
       Net::SMTP.start('localhost', port, user: 'account', password: 'password', authtype: :plain){}
 
       port = fake_server_start(auth: 'plain')
+      Net::SMTP.start('localhost', port, authtype: "PLAIN",
+                      auth: {username: 'account', password: 'password'}){}
+
+      port = fake_server_start(auth: 'plain')
+      Net::SMTP.start('localhost', port, auth: {username: 'account',
+                                                password: 'password',
+                                                type: :plain}){}
+
+      port = fake_server_start(auth: 'plain')
       assert_raise Net::SMTPAuthenticationError do
         Net::SMTP.start('localhost', port, user: 'account', password: 'invalid', authtype: :plain){}
       end


### PR DESCRIPTION
Several SASL mechanisms have zero or one required parameters, so it doesn't make sense to require positional "user" and "secret" parameters.  And in some cases, the semantics of the parameters don't align cleanly with the semantics implied by "user" and "secret".

And many SASL mechanisms will need to be able to take extra arguments.  For example: `authzid` for many mechanisms, `warn_deprecations` for deprecated mechanisms, `min_iterations` for `SCRAM-*`, anonymous_message for `ANONYMOUS`, and so on.  Also, although it is convenient to use `username` as an (ambiguous) alias for `authcid` _or_ `authzid`, and `secret` as an (ambiguous) alias for `password` or `oauth2_token`, it is also useful to have keyword parameters that keep stable semantics across many different mechanisms.

So, the API needs to be updated so that 1) positional parameters are not required, 2) keyword parameters are enabled.  For semantic clarity, positional parameters should be seen as a convenience, and keyword parameters should be considered the basic form.

This PR does several things (each split into their own commit):
* `#authenticate` changes:
  * keyword args are forwarded to the authenticator (#74)
  * positional args are optional
  * `type` can be sent as a keyword parameter
* `Net::SMTP.start` and `#start` changes
  * Add `auth` parameter: a hash of keyword arguments for `#authenticate`.  For backward compatibility, the existing `username`, `secret`, etc are still sent as positional arguments. (#74)
* Adds keyword parameters to all existing authenticators.  This makes `user` and `secret` positional arguments optional, as keyword args can be used instead.

As currently written, this PR depends on the following other PRs:
* ~#65~
* #74
* #72 
  * #66 
* #73
  * #67