### PR TITLE
Delegate checking auth args to the authenticator

### DIFF
--- a/lib/net/smtp/authenticator.rb
+++ b/lib/net/smtp/authenticator.rb
@@ -15,6 +15,15 @@ module Net
         Authenticator.auth_classes[type]
       end
 
+      def self.check_args(user_arg = nil, secret_arg = nil, *, **)
+        unless user_arg
+          raise ArgumentError, 'SMTP-AUTH requested but missing user name'
+        end
+        unless secret_arg
+          raise ArgumentError, 'SMTP-AUTH requested but missing secret phrase'
+        end
+      end
+
       attr_reader :smtp
 
       def initialize(smtp)


### PR DESCRIPTION
Each authenticator has different parameters, so argument validation must be delegated to the authenticator classes.

This PR builds on #67 to avoid merge conflicts.