### PR TITLE
Forward `authenticate` keyword arguments

### DIFF
--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -869,10 +869,10 @@ module Net
     # All arguments-other than +authtype+-are forwarded to the authenticator.
     # Different authenticators may interpret the +user+ and +secret+
     # arguments differently.
-    def authenticate(user, secret, authtype = DEFAULT_AUTH_TYPE)
-      check_auth_args authtype, user, secret
+    def authenticate(user, secret, authtype = DEFAULT_AUTH_TYPE, **kwargs, &block)
+      check_auth_args authtype, user, secret, **kwargs
       authenticator = Authenticator.auth_class(authtype).new(self)
-      authenticator.auth(user, secret)
+      authenticator.auth(user, secret, **kwargs, &block)
     end
 
     private


### PR DESCRIPTION
* `.start` and `#start` now take an `auth` keyword argument, which is an optional hash of keyword arguments that will be forwarded to `#authenticate`.
* `#authenticate` now forwards its keyword arguments (and its block argument) to its chosen authenticator.
 
_Note:_ this isn't tested in this PR because the tests I originally wrote for it don't work without authenticators that accept keyword arguments.  This PR doesn't update existing authenticators or adding any new authenticator.  See #71.