### PR TITLE
Fix version extraction to work with non ASCII characters with any `LANG`

### DIFF
--- a/net-smtp.gemspec
+++ b/net-smtp.gemspec
@@ -2,7 +2,7 @@
 
 name = File.basename(__FILE__, ".gemspec")
 version = ["lib", Array.new(name.count("-"), "..").join("/")].find do |dir|
-  break File.foreach(File.join(__dir__, dir, "#{name.tr('-', '/')}.rb")) do |line|
+  break File.foreach(File.join(__dir__, dir, "#{name.tr('-', '/')}.rb"), :encoding => "UTF-8") do |line|
     /^\s*VERSION\s*=\s*"(.*)"/ =~ line and break $1
   end rescue nil
 end


### PR DESCRIPTION
d9fe72afe9 introduced a non-ASCII character (U+2014) in comment but Regex match failed with non UTF-8 locale.

The extraction failure results in the following build error while building ruby with `gems/bundled_gems` including git-revision specified net-smtp.

```
Building net-smtp@2b251244b7678c5e84e620584c26242f36c1e91a to gems/net-smtp-0.4.0.gem
Invalid gemspec in [net-smtp.gemspec]: undefined method `prerelease?' for nil:NilClass
Failed to load gems/src/net-smtp/net-smtp.gemspec
```

https://rubyci.s3.amazonaws.com/debian-riscv64/ruby-master/log/20240104T070017Z.fail.html.gz

This commit fixes it by specifying encoding explicitly.