### PR TITLE
Use ascii character for documentation

### DIFF
--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -185,7 +185,7 @@ module Net
   #     Net::SMTP.start('your.smtp.server', 25,
   #                     user: 'Your Account', secret: 'Your Password', authtype: :plain)
   #
-  # Support for other SASL mechanisms—such as +EXTERNAL+, +OAUTHBEARER+,
+  # Support for other SASL mechanisms-such as +EXTERNAL+, +OAUTHBEARER+,
   # +SCRAM-SHA-256+, and +XOAUTH2+—will be added in a future release.
   #
   # The +LOGIN+ and +CRAM-MD5+ mechanisms are still available for backwards


### PR DESCRIPTION
It caused https://rubyci.s3.amazonaws.com/freebsd12/ruby-master/log/20240104T083002Z.fail.html.gz