### PR TITLE
Make the test suite compatible with --enable-frozen-string-literal

### DIFF
--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -672,7 +672,7 @@ module Net
     end
 
     def ehlo(_)
-      res = ["220-servername\r\n"]
+      res = [+"220-servername\r\n"]
       @capa.each do |k, v|
         case v
         when nil, false


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/20205

Since `net-smtp` is tested as part of ruby-core CI, it needs to be compatible with the `--enable-frozen-string-literal` option.