### PR TITLE
Enabled windows-latest on GHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,11 @@ jobs:
       matrix:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         os: [ ubuntu-latest, macos-latest, windows-latest ]
+        exclude:
+          - ruby: 2.6
+            os: windows-latest
+          - ruby: 2.7
+            os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -789,7 +789,7 @@ module Net
           @sock.puts "502 5.5.2 Error: command not recognized\r\n"
         end
       end
-    rescue Errno::ECONNRESET
+    rescue Errno::ECONNRESET, Errno::ECONNABORTED
       nil
     end
   end


### PR DESCRIPTION
I'm working to enable to test all of bundled gems at https://github.com/ruby/ruby/pull/12193

`net-smtp` failed with Windows platform now. I fixed that in this PR.