### PR TITLE
Add Net::SMTP::Address#to_str

### DIFF
--- a/lib/net/smtp.rb
+++ b/lib/net/smtp.rb
@@ -1152,6 +1152,7 @@ module Net
       def to_s
         @address
       end
+      alias to_str to_s
     end
   end   # class SMTP
 

--- a/test/net/smtp/test_smtp.rb
+++ b/test/net/smtp/test_smtp.rb
@@ -102,6 +102,8 @@ module Net
     def test_address
       a = Net::SMTP::Address.new('foo@example.com', 'p0=123', {p1: 456}, p2: nil, p3: '789')
       assert_equal 'foo@example.com', a.address
+      assert_equal '<foo@example.com>', "<#{a}>" # Address#to_s
+      assert_match(/\Afoo@example\.com\z/, a) # Address#to_str
       assert_equal ['p0=123', 'p1=456', 'p2', 'p3=789'], a.parameters
     end
 


### PR DESCRIPTION
Add implicit conversion from Net::SMTP::Address to String. Test both explicit and implicit conversion from Net::SMTP::Address to String.

The implicit conversion can be useful when using `Mail::SmtpEnvelope` with a `Net::SMTP::Address` instance instead of a `String`, and it’s being passed to `Regexp#match?` in https://github.com/mikel/mail/blob/73db11a6463ec330a36d68cfb77ef99511126cb0/lib/mail/smtp_envelope.rb#L50