### PR TITLE
Restore gemspec file to gem package

### DIFF
--- a/net-smtp.gemspec
+++ b/net-smtp.gemspec
@@ -22,7 +22,9 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
 
-  spec.files = `git ls-files README.md NEWS.md LICENSE.txt net-smtp.gemspec lib`.split
+  spec.files = Dir.chdir(File.expand_path('..', __FILE__)) do
+    `git ls-files README.md NEWS.md LICENSE.txt net-smtp.gemspec lib`.split
+  end
   spec.require_paths = ["lib"]
 
   spec.add_dependency "net-protocol"

--- a/net-smtp.gemspec
+++ b/net-smtp.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
 
-  spec.files = `git ls-files README.md NEWS.md LICENSE.txt lib`.split
+  spec.files = `git ls-files README.md NEWS.md LICENSE.txt net-smtp.gemspec lib`.split
   spec.require_paths = ["lib"]
 
   spec.add_dependency "net-protocol"


### PR DESCRIPTION
This file is required by `rbinstall.rb` in ruby/ruby repo.